### PR TITLE
[Feature/3] 회원 도메인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'com.h2database:h2'
+	testImplementation("org.assertj:assertj-core:3.25.3")
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,11 @@ dependencies {
 	// security
 	implementation 'org.springframework.security:spring-security-crypto'
 
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
 	// db
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// security
+	implementation 'org.springframework.security:spring-security-crypto'
+
 	// db
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/flab/fpay/aop/LoginMemberIdCheck.java
+++ b/src/main/java/com/flab/fpay/aop/LoginMemberIdCheck.java
@@ -1,0 +1,11 @@
+package com.flab.fpay.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface LoginMemberIdCheck {
+}

--- a/src/main/java/com/flab/fpay/aop/LoginMemberIdCheckAspect.java
+++ b/src/main/java/com/flab/fpay/aop/LoginMemberIdCheckAspect.java
@@ -18,12 +18,12 @@ public class LoginMemberIdCheckAspect {
      * 엑세스 토큰에서 추출한 memberId와 실제 요청의 memberId가 일치하는지 검사
      */
     @Before("@annotation(com.flab.fpay.aop.LoginMemberIdCheck) && args(memberId)")
-    public void checkLoginMemberId(final Long memberId) {
+    public void checkLoginMemberId(final long memberId) {
         HttpServletRequest req = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
 
-        Long authMemberId = Long.valueOf(req.getAttribute(AuthConstant.MEMBER_ID_CLAIM_KEY).toString());
+        long authMemberId = Long.parseLong(req.getAttribute(AuthConstant.MEMBER_ID_CLAIM_KEY).toString());
 
-        if (!authMemberId.equals(memberId)) {
+        if (authMemberId != memberId) {
             throw new ApiException(ErrorCode.BAD_REQUEST, "invalid member request");
         }
     }

--- a/src/main/java/com/flab/fpay/aop/LoginMemberIdCheckAspect.java
+++ b/src/main/java/com/flab/fpay/aop/LoginMemberIdCheckAspect.java
@@ -1,0 +1,30 @@
+package com.flab.fpay.aop;
+
+import com.flab.fpay.domain.auth.constant.AuthConstant;
+import com.flab.fpay.domain.common.ErrorCode;
+import com.flab.fpay.exception.ApiException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+public class LoginMemberIdCheckAspect {
+
+    /**
+     * 엑세스 토큰에서 추출한 memberId와 실제 요청의 memberId가 일치하는지 검사
+     */
+    @Before("@annotation(com.flab.fpay.aop.LoginMemberIdCheck) && args(memberId)")
+    public void checkLoginMemberId(final Long memberId) {
+        HttpServletRequest req = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+
+        Long authMemberId = Long.valueOf(req.getAttribute(AuthConstant.MEMBER_ID_CLAIM_KEY).toString());
+
+        if (!authMemberId.equals(memberId)) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "invalid member request");
+        }
+    }
+}

--- a/src/main/java/com/flab/fpay/config/EncryptionConfig.java
+++ b/src/main/java/com/flab/fpay/config/EncryptionConfig.java
@@ -1,0 +1,14 @@
+package com.flab.fpay.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class EncryptionConfig {
+    @Bean
+    public PasswordEncoder bcryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/flab/fpay/controller/v1/auth/AuthController.java
+++ b/src/main/java/com/flab/fpay/controller/v1/auth/AuthController.java
@@ -1,0 +1,9 @@
+package com.flab.fpay.controller.v1.auth;
+
+import com.flab.fpay.domain.auth.dto.request.RefreshTokenRequest;
+import com.flab.fpay.domain.common.dto.response.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+
+public interface AuthController {
+    ResponseEntity<SuccessResponse> refreshToken(RefreshTokenRequest refreshTokenRequest);
+}

--- a/src/main/java/com/flab/fpay/controller/v1/auth/impl/AuthControllerImpl.java
+++ b/src/main/java/com/flab/fpay/controller/v1/auth/impl/AuthControllerImpl.java
@@ -1,0 +1,30 @@
+package com.flab.fpay.controller.v1.auth.impl;
+
+import com.flab.fpay.controller.v1.auth.AuthController;
+import com.flab.fpay.domain.auth.dto.request.RefreshTokenRequest;
+import com.flab.fpay.domain.auth.dto.response.RefreshTokenResponse;
+import com.flab.fpay.domain.common.dto.response.SuccessResponse;
+import com.flab.fpay.facade.auth.AuthFacadeService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthControllerImpl implements AuthController {
+
+    private final AuthFacadeService authFacadeService;
+
+    public AuthControllerImpl(AuthFacadeService authFacadeService) {
+        this.authFacadeService = authFacadeService;
+    }
+
+    @Override
+    @PostMapping("/v1/auth/refresh")
+    public ResponseEntity<SuccessResponse> refreshToken(@Valid @RequestBody RefreshTokenRequest refreshTokenRequest) {
+        RefreshTokenResponse refreshTokenResponse = authFacadeService.refreshToken(refreshTokenRequest);
+        return ResponseEntity.status(HttpStatus.OK).body(new SuccessResponse(refreshTokenResponse));
+    }
+}

--- a/src/main/java/com/flab/fpay/controller/v1/member/MemberController.java
+++ b/src/main/java/com/flab/fpay/controller/v1/member/MemberController.java
@@ -8,4 +8,5 @@ import org.springframework.http.ResponseEntity;
 public interface MemberController {
     ResponseEntity<SuccessResponse> signUp(SignUpRequest request);
     ResponseEntity<SuccessResponse> signIn(SignInRequest request);
+    ResponseEntity<SuccessResponse> getMemberInfo(long memberId);
 }

--- a/src/main/java/com/flab/fpay/controller/v1/member/MemberController.java
+++ b/src/main/java/com/flab/fpay/controller/v1/member/MemberController.java
@@ -1,4 +1,11 @@
 package com.flab.fpay.controller.v1.member;
 
+import com.flab.fpay.domain.common.dto.response.SuccessResponse;
+import com.flab.fpay.domain.member.dto.request.SignInRequest;
+import com.flab.fpay.domain.member.dto.request.SignUpRequest;
+import org.springframework.http.ResponseEntity;
+
 public interface MemberController {
+    ResponseEntity<SuccessResponse> signUp(SignUpRequest request);
+    ResponseEntity<SuccessResponse> signIn(SignInRequest request);
 }

--- a/src/main/java/com/flab/fpay/controller/v1/member/impl/MemberControllerImpl.java
+++ b/src/main/java/com/flab/fpay/controller/v1/member/impl/MemberControllerImpl.java
@@ -1,21 +1,20 @@
 package com.flab.fpay.controller.v1.member.impl;
 
+import com.flab.fpay.aop.LoginMemberIdCheck;
 import com.flab.fpay.controller.v1.member.MemberController;
 import com.flab.fpay.domain.common.dto.response.SuccessResponse;
 import com.flab.fpay.domain.member.dto.request.SignInRequest;
 import com.flab.fpay.domain.member.dto.request.SignUpRequest;
+import com.flab.fpay.domain.member.dto.response.MemberDetailResponse;
 import com.flab.fpay.domain.member.dto.response.SignInResponse;
 import com.flab.fpay.facade.member.MemberFacadeService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class MemberControllerImpl implements MemberController {
-
     private final MemberFacadeService memberFacadeService;
 
     public MemberControllerImpl(MemberFacadeService memberFacadeService) {
@@ -35,5 +34,13 @@ public class MemberControllerImpl implements MemberController {
         SignInResponse signInResponse = memberFacadeService.signIn(signInRequest);
 
         return ResponseEntity.status(HttpStatus.OK).body(new SuccessResponse(signInResponse));
+    }
+
+    @Override
+    @GetMapping("v1/member/{memberId}")
+    @LoginMemberIdCheck
+    public ResponseEntity<SuccessResponse> getMemberInfo(@PathVariable long memberId) {
+        MemberDetailResponse memberResponse = memberFacadeService.getMemberById(memberId);
+        return ResponseEntity.status(HttpStatus.OK).body(new SuccessResponse(memberResponse));
     }
 }

--- a/src/main/java/com/flab/fpay/controller/v1/member/impl/MemberControllerImpl.java
+++ b/src/main/java/com/flab/fpay/controller/v1/member/impl/MemberControllerImpl.java
@@ -1,7 +1,14 @@
 package com.flab.fpay.controller.v1.member.impl;
 
 import com.flab.fpay.controller.v1.member.MemberController;
+import com.flab.fpay.domain.common.dto.response.SuccessResponse;
+import com.flab.fpay.domain.member.dto.request.SignUpRequest;
 import com.flab.fpay.facade.member.MemberFacadeService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -11,5 +18,12 @@ public class MemberControllerImpl implements MemberController {
 
     public MemberControllerImpl(MemberFacadeService memberFacadeService) {
         this.memberFacadeService = memberFacadeService;
+    }
+
+    @PostMapping("/v1/member/sign-up")
+    public ResponseEntity<SuccessResponse> signUp(@RequestBody @Valid SignUpRequest request) {
+        memberFacadeService.signUp(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(new SuccessResponse(null));
     }
 }

--- a/src/main/java/com/flab/fpay/controller/v1/member/impl/MemberControllerImpl.java
+++ b/src/main/java/com/flab/fpay/controller/v1/member/impl/MemberControllerImpl.java
@@ -2,7 +2,9 @@ package com.flab.fpay.controller.v1.member.impl;
 
 import com.flab.fpay.controller.v1.member.MemberController;
 import com.flab.fpay.domain.common.dto.response.SuccessResponse;
+import com.flab.fpay.domain.member.dto.request.SignInRequest;
 import com.flab.fpay.domain.member.dto.request.SignUpRequest;
+import com.flab.fpay.domain.member.dto.response.SignInResponse;
 import com.flab.fpay.facade.member.MemberFacadeService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -20,10 +22,18 @@ public class MemberControllerImpl implements MemberController {
         this.memberFacadeService = memberFacadeService;
     }
 
+    @Override
     @PostMapping("/v1/member/sign-up")
     public ResponseEntity<SuccessResponse> signUp(@RequestBody @Valid SignUpRequest request) {
         memberFacadeService.signUp(request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(new SuccessResponse(null));
+    }
+    @Override
+    @PostMapping("/v1/member/sign-in")
+    public ResponseEntity<SuccessResponse> signIn(@Valid @RequestBody SignInRequest signInRequest) {
+        SignInResponse signInResponse = memberFacadeService.signIn(signInRequest);
+
+        return ResponseEntity.status(HttpStatus.OK).body(new SuccessResponse(signInResponse));
     }
 }

--- a/src/main/java/com/flab/fpay/domain/auth/constant/AuthConstant.java
+++ b/src/main/java/com/flab/fpay/domain/auth/constant/AuthConstant.java
@@ -1,0 +1,8 @@
+package com.flab.fpay.domain.auth.constant;
+
+public class AuthConstant {
+    public static String BEARER_PREFIX = "Bearer ";
+    public static String AUTHORIZATION_HEADER = "Authorization";
+    public static String MEMBER_ID_CLAIM_KEY = "memberId";
+    public static String DEVICE_ID_CLAIM_KEY = "deviceId";
+}

--- a/src/main/java/com/flab/fpay/domain/auth/dto/AuthTokenDto.java
+++ b/src/main/java/com/flab/fpay/domain/auth/dto/AuthTokenDto.java
@@ -1,0 +1,45 @@
+package com.flab.fpay.domain.auth.dto;
+
+public class AuthTokenDto {
+    private final String accessToken;
+    private final String refreshToken;
+
+    private AuthTokenDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public static AuthTokenDtoBuilder builder() {
+        return new AuthTokenDtoBuilder();
+    }
+
+    public static class AuthTokenDtoBuilder {
+        private String accessToken;
+        private String refreshToken;
+
+        private AuthTokenDtoBuilder() {
+        }
+
+        public AuthTokenDtoBuilder accessToken(String accessToken) {
+            this.accessToken = accessToken;
+            return this;
+        }
+
+        public AuthTokenDtoBuilder refreshToken(String refreshToken) {
+            this.refreshToken = refreshToken;
+            return this;
+        }
+
+        public AuthTokenDto build() {
+            return new AuthTokenDto(accessToken, refreshToken);
+        }
+    }
+}

--- a/src/main/java/com/flab/fpay/domain/auth/dto/JwtClaimDto.java
+++ b/src/main/java/com/flab/fpay/domain/auth/dto/JwtClaimDto.java
@@ -1,0 +1,74 @@
+package com.flab.fpay.domain.auth.dto;
+
+import java.util.Date;
+
+public class JwtClaimDto {
+    private final Date issuedAt;
+    private final Date expiredAt;
+    private final long memberId;
+    private final String deviceId;
+
+    private JwtClaimDto(Date issuedAt, Date expiredAt, long memberId, String deviceId) {
+        this.issuedAt = issuedAt;
+        this.expiredAt = expiredAt;
+        this.memberId = memberId;
+        this.deviceId = deviceId;
+    }
+
+    public Date getIssuedAt() {
+        return issuedAt;
+    }
+
+    public Date getExpiredAt() {
+        return expiredAt;
+    }
+
+    public long getMemberId() {
+        return memberId;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public static JwtClaimDtoBuilder builder() {
+        return new JwtClaimDtoBuilder();
+    }
+
+    public static class JwtClaimDtoBuilder {
+        private Date issuedAt;
+        private Date expiredAt;
+        private long memberId;
+        private String deviceId;
+
+        private JwtClaimDtoBuilder() {}
+
+        public JwtClaimDtoBuilder builder() {
+            return new JwtClaimDtoBuilder();
+        }
+
+        public JwtClaimDtoBuilder issuedAt(Date issuedAt) {
+            this.issuedAt = issuedAt;
+            return this;
+        }
+
+        public JwtClaimDtoBuilder expiredAt(Date expiredAt) {
+            this.expiredAt = expiredAt;
+            return this;
+        }
+
+        public JwtClaimDtoBuilder memberId(long memberId) {
+            this.memberId = memberId;
+            return this;
+        }
+
+        public JwtClaimDtoBuilder deviceId(String deviceId) {
+            this.deviceId = deviceId;
+            return this;
+        }
+
+        public JwtClaimDto build() {
+            return new JwtClaimDto(this.issuedAt, this.expiredAt, this.memberId, this.deviceId);
+        }
+    }
+}

--- a/src/main/java/com/flab/fpay/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/flab/fpay/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,23 @@
+package com.flab.fpay.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public class RefreshTokenRequest {
+    @NotNull
+    private String refreshToken;
+    @NotNull
+    private String deviceId;
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public RefreshTokenRequest(String refreshToken, String deviceId) {
+        this.refreshToken = refreshToken;
+        this.deviceId = deviceId;
+    }
+}

--- a/src/main/java/com/flab/fpay/domain/auth/dto/response/RefreshTokenResponse.java
+++ b/src/main/java/com/flab/fpay/domain/auth/dto/response/RefreshTokenResponse.java
@@ -1,0 +1,45 @@
+package com.flab.fpay.domain.auth.dto.response;
+
+public class RefreshTokenResponse {
+    private final String accessToken;
+    private final String refreshToken;
+
+    private RefreshTokenResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public static RefreshTokenResponseBuilder builder() {
+        return new RefreshTokenResponseBuilder();
+    }
+
+    public static class RefreshTokenResponseBuilder {
+        private String accessToken;
+        private String refreshToken;
+
+        private RefreshTokenResponseBuilder() {
+        }
+
+        public RefreshTokenResponseBuilder accessToken(String accessToken) {
+            this.accessToken = accessToken;
+            return this;
+        }
+
+        public RefreshTokenResponseBuilder refreshToken(String refreshToken) {
+            this.refreshToken = refreshToken;
+            return this;
+        }
+
+        public RefreshTokenResponse build() {
+            return new RefreshTokenResponse(accessToken, refreshToken);
+        }
+    }
+}

--- a/src/main/java/com/flab/fpay/domain/auth/entity/AuthToken.java
+++ b/src/main/java/com/flab/fpay/domain/auth/entity/AuthToken.java
@@ -6,7 +6,12 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "auth_token")
+@Table(
+        name = "auth_token",
+        indexes = {
+                @Index(name = "uidx_at_refreshtoken", columnList = "refresh_token", unique = true)
+        }
+)
 public class AuthToken extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/flab/fpay/domain/auth/entity/AuthToken.java
+++ b/src/main/java/com/flab/fpay/domain/auth/entity/AuthToken.java
@@ -1,0 +1,94 @@
+package com.flab.fpay.domain.auth.entity;
+
+import com.flab.fpay.domain.common.entity.BaseEntity;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "auth_token")
+public class AuthToken extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private long id;
+
+    @Column(name = "member_id")
+    private long memberId;
+
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
+    @Column(name = "device_id")
+    private String deviceId;
+
+    @Column(name = "issued_at")
+    private LocalDateTime issuedAt;
+
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt;
+
+    protected AuthToken() {
+    }
+
+    private AuthToken(long memberId, String refreshToken, String deviceId, LocalDateTime issuedAt, LocalDateTime expiredAt) {
+        this.memberId = memberId;
+        this.refreshToken = refreshToken;
+        this.deviceId = deviceId;
+        this.issuedAt = issuedAt;
+        this.expiredAt = expiredAt;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public long getMemberId() {
+        return memberId;
+    }
+
+    public static AuthTokenBuilder builder() {
+        return new AuthTokenBuilder();
+    }
+
+    public static class AuthTokenBuilder {
+        private long memberId;
+        private String refreshToken;
+        private String deviceId;
+        private LocalDateTime issuedAt;
+        private LocalDateTime expiredAt;
+        private AuthTokenBuilder() {}
+
+        public AuthTokenBuilder builder() {
+            return new AuthTokenBuilder();
+        }
+        public AuthTokenBuilder memberId(long memberId) {
+            this.memberId = memberId;
+            return this;
+        }
+
+        public AuthTokenBuilder refreshToken(String refreshToken) {
+            this.refreshToken = refreshToken;
+            return this;
+        }
+
+        public AuthTokenBuilder deviceId(String deviceId) {
+            this.deviceId = deviceId;
+            return this;
+        }
+
+        public AuthTokenBuilder issuedAt(LocalDateTime issuedAt) {
+            this.issuedAt = issuedAt;
+            return this;
+        }
+
+        public AuthTokenBuilder expiredAt(LocalDateTime expiredAt) {
+            this.expiredAt = expiredAt;
+            return this;
+        }
+
+        public AuthToken build() {
+            return new AuthToken(this.memberId, this.refreshToken, this.deviceId, this.issuedAt, this.expiredAt);
+        }
+    }
+}

--- a/src/main/java/com/flab/fpay/domain/auth/entity/AuthToken.java
+++ b/src/main/java/com/flab/fpay/domain/auth/entity/AuthToken.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Table(
         name = "auth_token",
         indexes = {
-                @Index(name = "uidx_at_refreshtoken", columnList = "refresh_token", unique = true)
+                @Index(name = "uidx_at_refreshtokendeviceid", columnList = "refresh_token, device_id", unique = true)
         }
 )
 public class AuthToken extends BaseEntity {

--- a/src/main/java/com/flab/fpay/domain/common/ErrorCode.java
+++ b/src/main/java/com/flab/fpay/domain/common/ErrorCode.java
@@ -3,8 +3,12 @@ package com.flab.fpay.domain.common;
 import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
+    // common
     NOT_FOUND(HttpStatus.NOT_FOUND, "resource not found"),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "internal error");
+
+    // member
+    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "duplicated email address"),
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/flab/fpay/domain/common/ErrorCode.java
+++ b/src/main/java/com/flab/fpay/domain/common/ErrorCode.java
@@ -6,6 +6,7 @@ public enum ErrorCode {
     // common
     NOT_FOUND(HttpStatus.NOT_FOUND, "resource not found"),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "internal error"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "invalid request"),
 
     // member
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "duplicated email address"),

--- a/src/main/java/com/flab/fpay/domain/common/ErrorCode.java
+++ b/src/main/java/com/flab/fpay/domain/common/ErrorCode.java
@@ -15,9 +15,6 @@ public enum ErrorCode {
     // auth
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "invalid token");
 
-    // member
-    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "duplicated email address"),
-
     private final HttpStatus status;
     private final String message;
 

--- a/src/main/java/com/flab/fpay/domain/common/ErrorCode.java
+++ b/src/main/java/com/flab/fpay/domain/common/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "member not found"),
     MEMBER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "member unauthorized"),
 
+    // auth
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "invalid token");
 
     // member
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "duplicated email address"),

--- a/src/main/java/com/flab/fpay/domain/common/ErrorCode.java
+++ b/src/main/java/com/flab/fpay/domain/common/ErrorCode.java
@@ -5,10 +5,13 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // common
     NOT_FOUND(HttpStatus.NOT_FOUND, "resource not found"),
-    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "internal error");
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "internal error"),
 
     // member
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "duplicated email address"),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "member not found"),
+    MEMBER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "member unauthorized"),
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/flab/fpay/domain/member/dto/MemberRegisterDto.java
+++ b/src/main/java/com/flab/fpay/domain/member/dto/MemberRegisterDto.java
@@ -1,0 +1,64 @@
+package com.flab.fpay.domain.member.dto;
+
+import com.flab.fpay.domain.member.entity.Member;
+import com.flab.fpay.domain.member.enums.MemberType;
+
+public class MemberRegisterDto {
+    private final String email;
+    private final String password;
+    private final MemberType memberType;
+
+    private MemberRegisterDto(String email, String password, MemberType memberType) {
+        this.email = email;
+        this.password = password;
+        this.memberType = memberType;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public MemberType getMemberType() {
+        return memberType;
+    }
+
+    public static Member toMemberEntity(MemberRegisterDto dto) {
+        return new Member(dto.getEmail(), dto.getPassword(), dto.getMemberType(), 0, false);
+    }
+
+    public static MemberRegisterDtoBuilder builder() {
+        return new MemberRegisterDtoBuilder();
+    }
+
+    public static class MemberRegisterDtoBuilder {
+        private String email;
+        private String password;
+        private MemberType memberType;
+
+        private MemberRegisterDtoBuilder() {
+        }
+
+        public MemberRegisterDtoBuilder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public MemberRegisterDtoBuilder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public MemberRegisterDtoBuilder memberType(MemberType memberType) {
+            this.memberType = memberType;
+            return this;
+        }
+
+        public MemberRegisterDto build() {
+            return new MemberRegisterDto(this.email, this.password, this.memberType);
+        }
+    }
+}

--- a/src/main/java/com/flab/fpay/domain/member/dto/MemberRegisterDto.java
+++ b/src/main/java/com/flab/fpay/domain/member/dto/MemberRegisterDto.java
@@ -1,6 +1,5 @@
 package com.flab.fpay.domain.member.dto;
 
-import com.flab.fpay.domain.member.entity.Member;
 import com.flab.fpay.domain.member.enums.MemberType;
 
 public class MemberRegisterDto {
@@ -24,10 +23,6 @@ public class MemberRegisterDto {
 
     public MemberType getMemberType() {
         return memberType;
-    }
-
-    public static Member toMemberEntity(MemberRegisterDto dto) {
-        return new Member(dto.getEmail(), dto.getPassword(), dto.getMemberType(), 0, false);
     }
 
     public static MemberRegisterDtoBuilder builder() {

--- a/src/main/java/com/flab/fpay/domain/member/dto/request/SignInRequest.java
+++ b/src/main/java/com/flab/fpay/domain/member/dto/request/SignInRequest.java
@@ -1,0 +1,32 @@
+package com.flab.fpay.domain.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class SignInRequest {
+    @Email
+    private final String email;
+    @NotBlank
+    private final String password;
+    @NotNull
+    private final String deviceId;
+
+    public SignInRequest(String email, String password, String deviceId) {
+        this.email = email;
+        this.password = password;
+        this.deviceId = deviceId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+}

--- a/src/main/java/com/flab/fpay/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/com/flab/fpay/domain/member/dto/request/SignUpRequest.java
@@ -1,4 +1,24 @@
 package com.flab.fpay.domain.member.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
 public class SignUpRequest {
+    @Email
+    private String email;
+    @NotBlank
+    private String password;
+
+    public SignUpRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
 }

--- a/src/main/java/com/flab/fpay/domain/member/dto/response/MemberDetailResponse.java
+++ b/src/main/java/com/flab/fpay/domain/member/dto/response/MemberDetailResponse.java
@@ -1,0 +1,59 @@
+package com.flab.fpay.domain.member.dto.response;
+
+import com.flab.fpay.domain.member.enums.MemberType;
+
+public class MemberDetailResponse {
+    private final String email;
+    private final MemberType memberType;
+    private final int balance;
+
+    private MemberDetailResponse(String email, MemberType memberType, int balance) {
+        this.email = email;
+        this.memberType = memberType;
+        this.balance = balance;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public MemberType getMemberType() {
+        return memberType;
+    }
+
+    public int getBalance() {
+        return balance;
+    }
+
+    public static MemberDetailResponseBuilder builder() {
+        return new MemberDetailResponseBuilder();
+    }
+
+    public static class MemberDetailResponseBuilder {
+        private String email;
+        private MemberType memberType;
+        private int balance;
+        private MemberDetailResponseBuilder() {
+        }
+
+        public MemberDetailResponseBuilder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public MemberDetailResponseBuilder memberType(MemberType memberType) {
+            this.memberType = memberType;
+            return this;
+        }
+
+        public MemberDetailResponseBuilder balance(int balance) {
+            this.balance = balance;
+            return this;
+        }
+
+        public MemberDetailResponse build() {
+            return new MemberDetailResponse(this.email, this.memberType, this.balance);
+        }
+    }
+
+}

--- a/src/main/java/com/flab/fpay/domain/member/dto/response/SignInResponse.java
+++ b/src/main/java/com/flab/fpay/domain/member/dto/response/SignInResponse.java
@@ -1,0 +1,45 @@
+package com.flab.fpay.domain.member.dto.response;
+
+public class SignInResponse {
+    private final String accessToken;
+    private final String refreshToken;
+
+    private SignInResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public static SignInResponseBuilder builder() {
+        return new SignInResponseBuilder();
+    }
+
+    public static class SignInResponseBuilder {
+        private String accessToken;
+        private String refreshToken;
+
+        private SignInResponseBuilder() {
+        }
+
+        public SignInResponseBuilder accessToken(String accessToken) {
+            this.accessToken = accessToken;
+            return this;
+        }
+
+        public SignInResponseBuilder refreshToken(String refreshToken) {
+            this.refreshToken = refreshToken;
+            return this;
+        }
+
+        public SignInResponse build() {
+            return new SignInResponse(accessToken, refreshToken);
+        }
+    }
+}

--- a/src/main/java/com/flab/fpay/domain/member/entity/Member.java
+++ b/src/main/java/com/flab/fpay/domain/member/entity/Member.java
@@ -26,12 +26,12 @@ public class Member extends BaseEntity {
     private int balance;
 
     @Column(name = "is_deleted")
-    private Boolean isDeleted;
+    private boolean isDeleted;
 
     protected Member() {
     }
 
-    public Member(String email, String password, MemberType memberType, int balance, Boolean isDeleted) {
+    private Member(String email, String password, MemberType memberType, int balance, Boolean isDeleted) {
         this.email = email;
         this.password = password;
         this.memberType = memberType;
@@ -39,8 +39,16 @@ public class Member extends BaseEntity {
         this.isDeleted = isDeleted;
     }
 
+    public long getId() {
+        return id;
+    }
+
     public String getEmail() {
         return email;
+    }
+
+    public String getPassword() {
+        return password;
     }
 
     public int getBalance() {
@@ -49,5 +57,49 @@ public class Member extends BaseEntity {
 
     public Boolean getDeleted() {
         return isDeleted;
+    }
+
+    public static MemberBuilder builder() {
+        return new MemberBuilder();
+    }
+
+    public static class MemberBuilder {
+        private String email;
+        private String password;
+        private MemberType memberType;
+        private int balance;
+        private boolean isDeleted;
+
+        private MemberBuilder() {
+        }
+
+        public MemberBuilder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public MemberBuilder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public MemberBuilder memberType(MemberType memberType) {
+            this.memberType = memberType;
+            return this;
+        }
+
+        public MemberBuilder balance(int balance) {
+            this.balance = balance;
+            return this;
+        }
+
+        public MemberBuilder isDeleted(boolean isDeleted) {
+            this.isDeleted = isDeleted;
+            return this;
+        }
+
+        public Member build() {
+            return new Member(this.email, this.password, this.memberType, this.balance, this.isDeleted);
+        }
     }
 }

--- a/src/main/java/com/flab/fpay/domain/member/entity/Member.java
+++ b/src/main/java/com/flab/fpay/domain/member/entity/Member.java
@@ -27,4 +27,27 @@ public class Member extends BaseEntity {
 
     @Column(name = "is_deleted")
     private Boolean isDeleted;
+
+    protected Member() {
+    }
+
+    public Member(String email, String password, MemberType memberType, int balance, Boolean isDeleted) {
+        this.email = email;
+        this.password = password;
+        this.memberType = memberType;
+        this.balance = balance;
+        this.isDeleted = isDeleted;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public int getBalance() {
+        return balance;
+    }
+
+    public Boolean getDeleted() {
+        return isDeleted;
+    }
 }

--- a/src/main/java/com/flab/fpay/domain/member/entity/Member.java
+++ b/src/main/java/com/flab/fpay/domain/member/entity/Member.java
@@ -5,7 +5,12 @@ import com.flab.fpay.domain.member.enums.MemberType;
 import jakarta.persistence.*;
 
 @Entity
-@Table(name = "member")
+@Table(
+        name = "member",
+        indexes = {
+                @Index(name = "uidx_m_email", columnList = "email", unique = true)
+        }
+)
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/flab/fpay/domain/member/entity/Member.java
+++ b/src/main/java/com/flab/fpay/domain/member/entity/Member.java
@@ -59,6 +59,10 @@ public class Member extends BaseEntity {
         return isDeleted;
     }
 
+    public MemberType getMemberType() {
+        return memberType;
+    }
+
     public static MemberBuilder builder() {
         return new MemberBuilder();
     }

--- a/src/main/java/com/flab/fpay/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/fpay/exception/GlobalExceptionHandler.java
@@ -6,9 +6,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -28,6 +32,22 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.METHOD_NOT_ALLOWED)
                 .body(new FailResponse("method not allowed"));
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<FailResponse> handleMethodArgumentNotValidExceptionException(MethodArgumentNotValidException exception) {
+        List<FieldError> fieldErrors = exception.getBindingResult().getFieldErrors();
+        StringBuilder errorMessage = new StringBuilder();
+
+        for (FieldError f : fieldErrors) {
+            errorMessage.append(f.getField())
+                    .append(" ")
+                    .append(f.getDefaultMessage());
+        }
+
+        FailResponse errorDto = new FailResponse(errorMessage.toString());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorDto);
     }
 
     private void logMessage(ErrorCode errorCode, Exception exception) {

--- a/src/main/java/com/flab/fpay/facade/auth/AuthFacadeService.java
+++ b/src/main/java/com/flab/fpay/facade/auth/AuthFacadeService.java
@@ -1,0 +1,41 @@
+package com.flab.fpay.facade.auth;
+
+import com.flab.fpay.domain.auth.dto.AuthTokenDto;
+import com.flab.fpay.domain.auth.dto.request.RefreshTokenRequest;
+import com.flab.fpay.domain.auth.dto.response.RefreshTokenResponse;
+import com.flab.fpay.domain.auth.entity.AuthToken;
+import com.flab.fpay.domain.common.ErrorCode;
+import com.flab.fpay.exception.ApiException;
+import com.flab.fpay.service.auth.AuthService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuthFacadeService {
+    private final AuthService authService;
+
+    public AuthFacadeService(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public RefreshTokenResponse refreshToken(RefreshTokenRequest refreshTokenRequest) {
+        AuthToken existingAuthToken =
+                authService.getTokenByRefreshToken(refreshTokenRequest.getRefreshToken(), refreshTokenRequest.getDeviceId());
+
+        if (existingAuthToken == null) {
+            throw new ApiException(ErrorCode.INVALID_TOKEN);
+        }
+
+        AuthTokenDto newAuthToken =
+                authService.createAuthToken(existingAuthToken.getMemberId(), refreshTokenRequest.getDeviceId());
+
+        authService.deleteExistingToken(existingAuthToken.getId());
+
+        return RefreshTokenResponse.builder()
+                .accessToken(newAuthToken.getAccessToken())
+                .refreshToken(newAuthToken.getRefreshToken())
+                .build();
+    }
+}

--- a/src/main/java/com/flab/fpay/facade/member/MemberFacadeService.java
+++ b/src/main/java/com/flab/fpay/facade/member/MemberFacadeService.java
@@ -5,6 +5,7 @@ import com.flab.fpay.domain.common.ErrorCode;
 import com.flab.fpay.domain.member.dto.MemberRegisterDto;
 import com.flab.fpay.domain.member.dto.request.SignInRequest;
 import com.flab.fpay.domain.member.dto.request.SignUpRequest;
+import com.flab.fpay.domain.member.dto.response.MemberDetailResponse;
 import com.flab.fpay.domain.member.dto.response.SignInResponse;
 import com.flab.fpay.domain.member.entity.Member;
 import com.flab.fpay.domain.member.enums.MemberType;
@@ -66,6 +67,21 @@ public class MemberFacadeService {
         return SignInResponse.builder()
                 .accessToken(authTokenDto.getAccessToken())
                 .refreshToken(authTokenDto.getRefreshToken())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public MemberDetailResponse getMemberById(long memberId) {
+        Member member = memberService.getMemberById(memberId);
+
+        if(member == null) {
+            throw new ApiException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        return MemberDetailResponse.builder()
+                .email(member.getEmail())
+                .memberType(member.getMemberType())
+                .balance(member.getBalance())
                 .build();
     }
 }

--- a/src/main/java/com/flab/fpay/facade/member/MemberFacadeService.java
+++ b/src/main/java/com/flab/fpay/facade/member/MemberFacadeService.java
@@ -1,14 +1,44 @@
 package com.flab.fpay.facade.member;
 
+import com.flab.fpay.domain.common.ErrorCode;
+import com.flab.fpay.domain.member.dto.MemberRegisterDto;
+import com.flab.fpay.domain.member.dto.request.SignUpRequest;
+import com.flab.fpay.domain.member.entity.Member;
+import com.flab.fpay.domain.member.enums.MemberType;
+import com.flab.fpay.exception.ApiException;
 import com.flab.fpay.service.member.MemberService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MemberFacadeService {
-
     private final MemberService memberService;
+    private final PasswordEncoder passwordEncoder;
 
-    public MemberFacadeService(MemberService memberService) {
+    public MemberFacadeService(MemberService memberService, PasswordEncoder passwordEncoder) {
         this.memberService = memberService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void signUp(SignUpRequest request) {
+        Member existingMember = memberService.getMemberByEmail(request.getEmail());
+
+        if(existingMember != null) {
+            throw new ApiException(ErrorCode.DUPLICATED_EMAIL);
+        }
+
+        String encryptedPassword = passwordEncoder.encode(request.getPassword());
+
+        MemberRegisterDto memberRegisterDto = MemberRegisterDto
+                .builder()
+                .email(request.getEmail())
+                .password(encryptedPassword)
+                .memberType(MemberType.MEMBER)
+                .build();
+
+        memberService.registerMember(memberRegisterDto);
     }
 }

--- a/src/main/java/com/flab/fpay/facade/member/MemberFacadeService.java
+++ b/src/main/java/com/flab/fpay/facade/member/MemberFacadeService.java
@@ -1,11 +1,15 @@
 package com.flab.fpay.facade.member;
 
+import com.flab.fpay.domain.auth.dto.AuthTokenDto;
 import com.flab.fpay.domain.common.ErrorCode;
 import com.flab.fpay.domain.member.dto.MemberRegisterDto;
+import com.flab.fpay.domain.member.dto.request.SignInRequest;
 import com.flab.fpay.domain.member.dto.request.SignUpRequest;
+import com.flab.fpay.domain.member.dto.response.SignInResponse;
 import com.flab.fpay.domain.member.entity.Member;
 import com.flab.fpay.domain.member.enums.MemberType;
 import com.flab.fpay.exception.ApiException;
+import com.flab.fpay.service.auth.AuthService;
 import com.flab.fpay.service.member.MemberService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -15,10 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class MemberFacadeService {
     private final MemberService memberService;
+    private final AuthService authService;
     private final PasswordEncoder passwordEncoder;
 
-    public MemberFacadeService(MemberService memberService, PasswordEncoder passwordEncoder) {
+    public MemberFacadeService(MemberService memberService, AuthService authService, PasswordEncoder passwordEncoder) {
         this.memberService = memberService;
+        this.authService = authService;
         this.passwordEncoder = passwordEncoder;
     }
 
@@ -40,5 +46,26 @@ public class MemberFacadeService {
                 .build();
 
         memberService.registerMember(memberRegisterDto);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public SignInResponse signIn(SignInRequest signInRequest) {
+        Member member = memberService.getMemberByEmail(signInRequest.getEmail());
+
+        if(member == null) {
+            throw new ApiException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        // 비밀번호 불일치
+        if (!passwordEncoder.matches(signInRequest.getPassword(), member.getPassword())) {
+            throw new ApiException(ErrorCode.MEMBER_UNAUTHORIZED);
+        }
+
+        AuthTokenDto authTokenDto =  authService.createAuthToken(member.getId(), signInRequest.getDeviceId());
+
+        return SignInResponse.builder()
+                .accessToken(authTokenDto.getAccessToken())
+                .refreshToken(authTokenDto.getRefreshToken())
+                .build();
     }
 }

--- a/src/main/java/com/flab/fpay/filter/AuthFilter.java
+++ b/src/main/java/com/flab/fpay/filter/AuthFilter.java
@@ -1,0 +1,87 @@
+package com.flab.fpay.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.fpay.domain.common.ErrorCode;
+import com.flab.fpay.domain.common.dto.response.FailResponse;
+import com.flab.fpay.utils.auth.JwtProvider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static com.flab.fpay.domain.auth.constant.AuthConstant.*;
+
+@Component
+public class AuthFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    public AuthFilter(JwtProvider jwtProvider, ObjectMapper objectMapper) {
+        this.jwtProvider = jwtProvider;
+        this.objectMapper = objectMapper;
+    }
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorization = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (authorization == null || authorization.isBlank()) {
+            this.createInvalidateTokenResponse(response);
+
+            return;
+        }
+
+        String accessToken = authorization.split(BEARER_PREFIX)[1];
+
+        try {
+            Claims claims = jwtProvider.decodeToken(accessToken);
+
+            request.setAttribute(MEMBER_ID_CLAIM_KEY, claims.get(MEMBER_ID_CLAIM_KEY));
+            request.setAttribute(DEVICE_ID_CLAIM_KEY, claims.get(DEVICE_ID_CLAIM_KEY));
+        } catch (ExpiredJwtException e) {
+            this.createInvalidateTokenResponse(response);
+
+            return;
+        } catch (Exception e) {
+            log.error("token decode exception occurred", e);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String[] excludePath = {
+                "/v1/member/sign-up",
+                "/v1/member/sign-in",
+                "/v1/auth/refresh",
+                // TODO: 상품, 가맹점, 계좌, 결제 API 리스트 추가
+        };
+
+        String path = request.getRequestURI();
+
+        return Arrays.stream(excludePath).anyMatch(path::startsWith);
+    }
+
+    private void createInvalidateTokenResponse(HttpServletResponse response) throws IOException {
+        FailResponse failResponse = new FailResponse(ErrorCode.INVALID_TOKEN.getMessage());
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        objectMapper.writeValue(response.getWriter(), failResponse);
+    }
+}

--- a/src/main/java/com/flab/fpay/repository/auth/AuthTokenJpaRepository.java
+++ b/src/main/java/com/flab/fpay/repository/auth/AuthTokenJpaRepository.java
@@ -1,0 +1,10 @@
+package com.flab.fpay.repository.auth;
+
+import com.flab.fpay.domain.auth.entity.AuthToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthTokenJpaRepository extends JpaRepository<AuthToken, Long> {
+    AuthToken findByMemberIdAndDeviceId(Long memberId, String deviceId);
+
+    AuthToken findByRefreshTokenAndDeviceId(String refreshToken, String deviceId);
+}

--- a/src/main/java/com/flab/fpay/repository/member/MemberJpaRepository.java
+++ b/src/main/java/com/flab/fpay/repository/member/MemberJpaRepository.java
@@ -4,5 +4,5 @@ import com.flab.fpay.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
-    Member findByEmail(String email);
+    Member findByEmailAndIsDeletedIsFalse(String email);
 }

--- a/src/main/java/com/flab/fpay/repository/member/MemberJpaRepository.java
+++ b/src/main/java/com/flab/fpay/repository/member/MemberJpaRepository.java
@@ -4,4 +4,5 @@ import com.flab.fpay.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+    Member findByEmail(String email);
 }

--- a/src/main/java/com/flab/fpay/service/auth/AuthService.java
+++ b/src/main/java/com/flab/fpay/service/auth/AuthService.java
@@ -1,0 +1,10 @@
+package com.flab.fpay.service.auth;
+
+import com.flab.fpay.domain.auth.dto.AuthTokenDto;
+import com.flab.fpay.domain.auth.entity.AuthToken;
+
+public interface AuthService {
+    AuthTokenDto createAuthToken(long memberId, String deviceId);
+    AuthToken getTokenByRefreshToken(String refreshToken, String deviceId);
+    void deleteExistingToken(long authTokenId);
+}

--- a/src/main/java/com/flab/fpay/service/auth/impl/AuthServiceImpl.java
+++ b/src/main/java/com/flab/fpay/service/auth/impl/AuthServiceImpl.java
@@ -1,0 +1,84 @@
+package com.flab.fpay.service.auth.impl;
+
+import com.flab.fpay.domain.auth.dto.AuthTokenDto;
+import com.flab.fpay.domain.auth.dto.JwtClaimDto;
+import com.flab.fpay.domain.auth.entity.AuthToken;
+import com.flab.fpay.repository.auth.AuthTokenJpaRepository;
+import com.flab.fpay.service.auth.AuthService;
+import com.flab.fpay.utils.auth.JwtProvider;
+import com.flab.fpay.utils.common.DateTimeUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Calendar;
+import java.util.Date;
+
+@Service
+public class AuthServiceImpl implements AuthService {
+    private final JwtProvider jwtProvider;
+    private final AuthTokenJpaRepository authTokenJpaRepository;
+    @Value("${auth.access-token-expired-hours}")
+    private int accessTokenExpiredHours;
+    @Value("${auth.refresh-token-expired-hours}")
+    private int refreshTokenExpiredHours;
+
+    public AuthServiceImpl(JwtProvider jwtProvider, AuthTokenJpaRepository authTokenJpaRepository) {
+        this.jwtProvider = jwtProvider;
+        this.authTokenJpaRepository = authTokenJpaRepository;
+    }
+
+    @Override
+    public AuthTokenDto createAuthToken(long memberId, String deviceId) {
+        Date issuedAt = new Date();
+
+        JwtClaimDto accessTokenClaim = JwtClaimDto.builder()
+                .issuedAt(issuedAt)
+                .expiredAt(getExpiredAt(issuedAt, accessTokenExpiredHours))
+                .memberId(memberId)
+                .deviceId(deviceId)
+                .build();
+
+        JwtClaimDto refreshTokenClaim = JwtClaimDto.builder()
+                .issuedAt(issuedAt)
+                .expiredAt(getExpiredAt(issuedAt, refreshTokenExpiredHours))
+                .memberId(memberId)
+                .deviceId(deviceId)
+                .build();
+
+        String accessToken = jwtProvider.createToken(accessTokenClaim);
+        String refreshToken = jwtProvider.createToken(refreshTokenClaim);
+
+        AuthToken authToken = AuthToken.builder()
+                .memberId(memberId)
+                .refreshToken(refreshToken)
+                .deviceId(deviceId)
+                .issuedAt(DateTimeUtils.dateToLocalDateTime(issuedAt))
+                .expiredAt(DateTimeUtils.dateToLocalDateTime(getExpiredAt(issuedAt, refreshTokenExpiredHours)))
+                .build();
+
+        authTokenJpaRepository.save(authToken);
+
+        return AuthTokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    @Override
+    public AuthToken getTokenByRefreshToken(String refreshToken, String deviceId) {
+        return authTokenJpaRepository.findByRefreshTokenAndDeviceId(refreshToken, deviceId);
+    }
+
+    @Override
+    public void deleteExistingToken(long authTokenId) {
+        authTokenJpaRepository.deleteById(authTokenId);
+    }
+
+    private Date getExpiredAt(Date issuedAt, int hours) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(issuedAt);
+        calendar.add(Calendar.HOUR_OF_DAY, hours);
+
+        return calendar.getTime();
+    }
+}

--- a/src/main/java/com/flab/fpay/service/member/MemberService.java
+++ b/src/main/java/com/flab/fpay/service/member/MemberService.java
@@ -1,4 +1,10 @@
 package com.flab.fpay.service.member;
 
+import com.flab.fpay.domain.member.dto.MemberRegisterDto;
+import com.flab.fpay.domain.member.entity.Member;
+
 public interface MemberService {
+    void registerMember(MemberRegisterDto memberRegisterDto);
+
+    Member getMemberByEmail(String email);
 }

--- a/src/main/java/com/flab/fpay/service/member/MemberService.java
+++ b/src/main/java/com/flab/fpay/service/member/MemberService.java
@@ -7,4 +7,6 @@ public interface MemberService {
     void registerMember(MemberRegisterDto memberRegisterDto);
 
     Member getMemberByEmail(String email);
+
+    Member getMemberById(long memberId);
 }

--- a/src/main/java/com/flab/fpay/service/member/impl/MemberServiceImpl.java
+++ b/src/main/java/com/flab/fpay/service/member/impl/MemberServiceImpl.java
@@ -1,5 +1,7 @@
 package com.flab.fpay.service.member.impl;
 
+import com.flab.fpay.domain.member.dto.MemberRegisterDto;
+import com.flab.fpay.domain.member.entity.Member;
 import com.flab.fpay.repository.member.MemberJpaRepository;
 import com.flab.fpay.service.member.MemberService;
 import org.springframework.stereotype.Service;
@@ -11,5 +13,17 @@ public class MemberServiceImpl implements MemberService {
 
     public MemberServiceImpl(MemberJpaRepository repository) {
         this.memberJpaRepository = repository;
+    }
+
+    @Override
+    public void registerMember(MemberRegisterDto memberRegisterDto) {
+        Member member = MemberRegisterDto.toMemberEntity(memberRegisterDto);
+
+        memberJpaRepository.save(member);
+    }
+
+    @Override
+    public Member getMemberByEmail(String email) {
+        return memberJpaRepository.findByEmail(email);
     }
 }

--- a/src/main/java/com/flab/fpay/service/member/impl/MemberServiceImpl.java
+++ b/src/main/java/com/flab/fpay/service/member/impl/MemberServiceImpl.java
@@ -17,7 +17,13 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public void registerMember(MemberRegisterDto memberRegisterDto) {
-        Member member = MemberRegisterDto.toMemberEntity(memberRegisterDto);
+        Member member = Member.builder()
+                .email(memberRegisterDto.getEmail())
+                .password(memberRegisterDto.getPassword())
+                .memberType(memberRegisterDto.getMemberType())
+                .balance(0)
+                .isDeleted(false)
+                .build();
 
         memberJpaRepository.save(member);
     }

--- a/src/main/java/com/flab/fpay/service/member/impl/MemberServiceImpl.java
+++ b/src/main/java/com/flab/fpay/service/member/impl/MemberServiceImpl.java
@@ -30,6 +30,11 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public Member getMemberByEmail(String email) {
-        return memberJpaRepository.findByEmail(email);
+        return memberJpaRepository.findByEmailAndIsDeletedIsFalse(email);
+    }
+
+    @Override
+    public Member getMemberById(long memberId) {
+        return memberJpaRepository.findById(memberId).orElse(null);
     }
 }

--- a/src/main/java/com/flab/fpay/utils/auth/JwtProvider.java
+++ b/src/main/java/com/flab/fpay/utils/auth/JwtProvider.java
@@ -1,0 +1,44 @@
+package com.flab.fpay.utils.auth;
+
+import com.flab.fpay.domain.auth.dto.JwtClaimDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+
+@Component
+public class JwtProvider {
+    @Value("${auth.jwt-secret-key}")
+    private String jwtSecretKey;
+    SecretKey key;
+
+    @PostConstruct
+    public void postConstruct() {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(jwtSecretKey));
+    }
+
+    public String createToken(JwtClaimDto claim) {
+        return Jwts.builder()
+                .claim("memberId", claim.getMemberId())
+                .claim("deviceId", claim.getDeviceId())
+                .issuedAt(claim.getIssuedAt())
+                .expiration(claim.getExpiredAt())
+                .signWith(key)
+                .compact();
+    }
+
+    public Claims decodeToken(String token) {
+        Jws<Claims> claimsJws = Jwts.parser()
+                .verifyWith(this.key)
+                .build()
+                .parseSignedClaims(token);
+
+        return claimsJws.getPayload();
+    }
+}

--- a/src/main/java/com/flab/fpay/utils/common/DateTimeUtils.java
+++ b/src/main/java/com/flab/fpay/utils/common/DateTimeUtils.java
@@ -1,0 +1,13 @@
+package com.flab.fpay.utils.common;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+public class DateTimeUtils {
+    public static LocalDateTime dateToLocalDateTime(Date date) {
+        return date.toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,8 @@ server:
     whitelabel:
       enabled: false
     path: /error
+
+auth:
+  access-token-expired-hours: 1
+  refresh-token-expired-hours: 720
+  jwt-secret-key:

--- a/src/test/java/com/flab/fpay/facade/FacadeTest.java
+++ b/src/test/java/com/flab/fpay/facade/FacadeTest.java
@@ -2,9 +2,11 @@ package com.flab.fpay.facade;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Transactional
 public abstract class FacadeTest {
 
 }

--- a/src/test/java/com/flab/fpay/facade/FacadeTest.java
+++ b/src/test/java/com/flab/fpay/facade/FacadeTest.java
@@ -1,0 +1,10 @@
+package com.flab.fpay.facade;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public abstract class FacadeTest {
+
+}

--- a/src/test/java/com/flab/fpay/facade/auth/AuthFacadeTest.java
+++ b/src/test/java/com/flab/fpay/facade/auth/AuthFacadeTest.java
@@ -1,0 +1,74 @@
+package com.flab.fpay.facade.auth;
+
+import com.flab.fpay.domain.auth.dto.request.RefreshTokenRequest;
+import com.flab.fpay.domain.auth.entity.AuthToken;
+import com.flab.fpay.domain.common.ErrorCode;
+import com.flab.fpay.exception.ApiException;
+import com.flab.fpay.facade.FacadeTest;
+import com.flab.fpay.repository.auth.AuthTokenJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AuthFacadeTest extends FacadeTest {
+    @Autowired
+    AuthFacadeService authFacadeService;
+    @Autowired
+    AuthTokenJpaRepository authTokenJpaRepository;
+
+    @Test
+    @DisplayName("토큰 재발급 성공")
+    public void tokenRefresh() {
+        // given
+        String refreshToken = "refreshToken";
+        String deviceId = "deviceId";
+        long memberId = 1L;
+
+        this.createAuthToken(memberId, refreshToken, deviceId);
+
+        RefreshTokenRequest request = new RefreshTokenRequest(refreshToken, deviceId);
+
+        // when
+        authFacadeService.refreshToken(request);
+
+        // then
+        AuthToken result = authTokenJpaRepository.findByMemberIdAndDeviceId(memberId, deviceId);
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰 발급 실패")
+    public void invalidRefreshToken() {
+        // given
+        String refreshToken = "refreshToken";
+        String deviceId = "deviceId";
+        long memberId = 1L;
+
+        this.createAuthToken(memberId, refreshToken, deviceId);
+
+        RefreshTokenRequest request = new RefreshTokenRequest("invalid refresh token", deviceId);
+
+        // when & then
+        assertThatThrownBy(() -> authFacadeService.refreshToken(request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(ErrorCode.INVALID_TOKEN.getMessage());
+    }
+
+    private AuthToken createAuthToken(long memberId, String refreshToken, String deviceId) {
+        AuthToken authToken = AuthToken.builder()
+                .memberId(memberId)
+                .refreshToken(refreshToken)
+                .deviceId(deviceId)
+                .issuedAt(LocalDateTime.now())
+                .expiredAt(LocalDateTime.now().plusMonths(1))
+                .build();
+
+        return authTokenJpaRepository.save(authToken);
+    }
+
+}

--- a/src/test/java/com/flab/fpay/facade/member/MemberFacadeTest.java
+++ b/src/test/java/com/flab/fpay/facade/member/MemberFacadeTest.java
@@ -1,0 +1,60 @@
+package com.flab.fpay.facade.member;
+
+import com.flab.fpay.domain.common.ErrorCode;
+import com.flab.fpay.domain.member.dto.request.SignUpRequest;
+import com.flab.fpay.domain.member.entity.Member;
+import com.flab.fpay.domain.member.enums.MemberType;
+import com.flab.fpay.exception.ApiException;
+import com.flab.fpay.facade.FacadeTest;
+import com.flab.fpay.repository.member.MemberJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class MemberFacadeTest extends FacadeTest {
+    @Autowired
+    MemberFacadeService memberFacadeService;
+
+    @Autowired
+    MemberJpaRepository memberRepository;
+
+    @Test
+    @DisplayName("회원가입 성공")
+    public void signUpSuccessTest() {
+        // given
+        String email = "test@email";
+        String password = "password";
+
+        SignUpRequest request = new SignUpRequest(email, password);
+
+        // when
+        memberFacadeService.signUp(request);
+
+        Member result = memberRepository.findAll().getFirst();
+
+        assertThat(result.getEmail()).isEqualTo(email);
+        assertThat(result.getBalance()).isZero();
+        assertThat(result.getDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("회원가입 이메일 중복 예외")
+    public void signUpDuplicatedEmail() {
+        // given
+        String email = "test@gmail";
+        String password = "password";
+
+        SignUpRequest request = new SignUpRequest(email, password);
+
+        Member member = new Member(email, password, MemberType.MEMBER, 0, false);
+        memberRepository.save(member);
+
+        // when & then
+        assertThatThrownBy(() -> memberFacadeService.signUp(request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(ErrorCode.DUPLICATED_EMAIL.getMessage());
+    }
+}

--- a/src/test/java/com/flab/fpay/facade/member/MemberFacadeTest.java
+++ b/src/test/java/com/flab/fpay/facade/member/MemberFacadeTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class MemberFacadeTest extends FacadeTest {
     @Autowired
     MemberFacadeService memberFacadeService;
-
     @Autowired
     MemberJpaRepository memberRepository;
 
@@ -49,7 +48,14 @@ public class MemberFacadeTest extends FacadeTest {
 
         SignUpRequest request = new SignUpRequest(email, password);
 
-        Member member = new Member(email, password, MemberType.MEMBER, 0, false);
+        Member member = Member.builder()
+                .email(email)
+                .password(password)
+                .memberType(MemberType.MEMBER)
+                .balance(0)
+                .isDeleted(false)
+                .build();
+
         memberRepository.save(member);
 
         // when & then

--- a/src/test/java/com/flab/fpay/facade/member/MemberFacadeTest.java
+++ b/src/test/java/com/flab/fpay/facade/member/MemberFacadeTest.java
@@ -1,7 +1,9 @@
 package com.flab.fpay.facade.member;
 
 import com.flab.fpay.domain.common.ErrorCode;
+import com.flab.fpay.domain.member.dto.request.SignInRequest;
 import com.flab.fpay.domain.member.dto.request.SignUpRequest;
+import com.flab.fpay.domain.member.dto.response.SignInResponse;
 import com.flab.fpay.domain.member.entity.Member;
 import com.flab.fpay.domain.member.enums.MemberType;
 import com.flab.fpay.exception.ApiException;
@@ -10,6 +12,7 @@ import com.flab.fpay.repository.member.MemberJpaRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -19,10 +22,12 @@ public class MemberFacadeTest extends FacadeTest {
     MemberFacadeService memberFacadeService;
     @Autowired
     MemberJpaRepository memberRepository;
+    @Autowired
+    PasswordEncoder passwordEncoder;
 
     @Test
     @DisplayName("회원가입 성공")
-    public void signUpSuccessTest() {
+    public void signUpSuccess() {
         // given
         String email = "test@email";
         String password = "password";
@@ -32,6 +37,7 @@ public class MemberFacadeTest extends FacadeTest {
         // when
         memberFacadeService.signUp(request);
 
+        // then
         Member result = memberRepository.findAll().getFirst();
 
         assertThat(result.getEmail()).isEqualTo(email);
@@ -62,5 +68,84 @@ public class MemberFacadeTest extends FacadeTest {
         assertThatThrownBy(() -> memberFacadeService.signUp(request))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(ErrorCode.DUPLICATED_EMAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    public void signInSuccess() {
+        // given
+        String email = "test@email";
+        String password = "password";
+        String deviceId = "deviceId";
+
+        Member member = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .memberType(MemberType.MEMBER)
+                .balance(0)
+                .isDeleted(false)
+                .build();
+
+        memberRepository.save(member);
+
+        // when
+        SignInRequest request = new SignInRequest(email, password, deviceId);
+        SignInResponse result = memberFacadeService.signIn(request);
+
+        // then
+        assertThat(result.getAccessToken()).isNotNull();
+        assertThat(result.getRefreshToken()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("로그인 비밀번호 불일치")
+    public void memberSignInInvalidPassword() {
+        // given
+        String email = "test@email";
+        String password = "password";
+        String deviceId = "deviceId";
+
+        Member member = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .memberType(MemberType.MEMBER)
+                .balance(0)
+                .isDeleted(false)
+                .build();
+
+        memberRepository.save(member);
+
+        SignInRequest request = new SignInRequest(email, "invalid password", deviceId);
+
+        // when & then
+        assertThatThrownBy(() -> memberFacadeService.signIn(request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(ErrorCode.MEMBER_UNAUTHORIZED.getMessage());
+    }
+
+    @Test
+    @DisplayName("로그인 이메일 불일치")
+    public void memberSignInInvalidEmail() {
+        // given
+        String email = "test@email";
+        String password = "password";
+        String deviceId = "deviceId";
+
+        Member member = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .memberType(MemberType.MEMBER)
+                .balance(0)
+                .isDeleted(false)
+                .build();
+
+        memberRepository.save(member);
+
+        SignInRequest request = new SignInRequest("invalid@email", password, deviceId);
+
+        // when & then
+        assertThatThrownBy(() -> memberFacadeService.signIn(request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/flab/fpay/integration/IntegrationTest.java
+++ b/src/test/java/com/flab/fpay/integration/IntegrationTest.java
@@ -3,9 +3,11 @@ package com.flab.fpay.integration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
+@Transactional
 public abstract class IntegrationTest {
 }

--- a/src/test/java/com/flab/fpay/integration/auth/v1/AuthIntegrationV1Test.java
+++ b/src/test/java/com/flab/fpay/integration/auth/v1/AuthIntegrationV1Test.java
@@ -1,0 +1,88 @@
+package com.flab.fpay.integration.auth.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.fpay.domain.auth.dto.request.RefreshTokenRequest;
+import com.flab.fpay.domain.auth.entity.AuthToken;
+import com.flab.fpay.domain.common.ErrorCode;
+import com.flab.fpay.integration.IntegrationTest;
+import com.flab.fpay.repository.auth.AuthTokenJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class AuthIntegrationV1Test extends IntegrationTest {
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    AuthTokenJpaRepository authTokenJpaRepository;
+
+    @Test
+    @DisplayName("토큰 재발급 성공")
+    public void tokenRefresh() throws Exception {
+        // given
+        String refreshToken = "refreshToken";
+        String deviceId = "deviceId";
+        long memberId = 1L;
+
+        this.createAuthToken(memberId, refreshToken, deviceId);
+
+        RefreshTokenRequest request = new RefreshTokenRequest(refreshToken, deviceId);
+
+        // when & then
+        mockMvc.perform(post("/v1/auth/refresh")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(jsonPath("$.payload.accessToken", notNullValue()))
+                .andExpect(jsonPath("$.payload.refreshToken", notNullValue()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰 발급 실패")
+    public void invalidRefreshToken() throws Exception {
+        // given
+        String refreshToken = "refreshToken";
+        String deviceId = "deviceId";
+        long memberId = 1L;
+
+        this.createAuthToken(memberId, refreshToken, deviceId);
+
+        RefreshTokenRequest request = new RefreshTokenRequest("invalid refresh token", deviceId);
+
+        // when & then
+        mockMvc.perform(post("/v1/auth/refresh")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(jsonPath("$.message", is(ErrorCode.INVALID_TOKEN.getMessage())))
+                .andExpect(status().isBadRequest());
+    }
+
+    private AuthToken createAuthToken(long memberId, String refreshToken, String deviceId) {
+        AuthToken authToken = AuthToken.builder()
+                .memberId(memberId)
+                .refreshToken(refreshToken)
+                .deviceId(deviceId)
+                .issuedAt(LocalDateTime.now())
+                .expiredAt(LocalDateTime.now().plusMonths(1))
+                .build();
+
+        return authTokenJpaRepository.save(authToken);
+    }
+}

--- a/src/test/java/com/flab/fpay/integration/member/v1/MemberIntegrationV1Test.java
+++ b/src/test/java/com/flab/fpay/integration/member/v1/MemberIntegrationV1Test.java
@@ -1,15 +1,20 @@
 package com.flab.fpay.integration.member.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.fpay.domain.auth.entity.AuthToken;
+import com.flab.fpay.domain.common.ErrorCode;
+import com.flab.fpay.domain.member.dto.request.SignInRequest;
 import com.flab.fpay.domain.member.dto.request.SignUpRequest;
 import com.flab.fpay.domain.member.entity.Member;
 import com.flab.fpay.domain.member.enums.MemberType;
 import com.flab.fpay.integration.IntegrationTest;
+import com.flab.fpay.repository.auth.AuthTokenJpaRepository;
 import com.flab.fpay.repository.member.MemberJpaRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,6 +34,12 @@ public class MemberIntegrationV1Test extends IntegrationTest {
 
     @Autowired
     MemberJpaRepository memberRepository;
+
+    @Autowired
+    AuthTokenJpaRepository authTokenJpaRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
 
     @Test
     @DisplayName("회원가입 성공")
@@ -119,5 +130,109 @@ public class MemberIntegrationV1Test extends IntegrationTest {
                 .andDo(print())
                 .andExpect(jsonPath("$.message", is("duplicated email address")))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void memberSignInSuccess() throws Exception {
+        // given
+        String email = "test@email";
+        String password = "password";
+        String deviceId = "deviceId";
+
+        Member savedMember = this.createMember(email, password);
+
+        SignInRequest request = new SignInRequest(email, password, deviceId);
+
+        // when & then
+        mockMvc.perform(post("/v1/member/sign-in")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                        .andDo(print())
+                        .andExpect(jsonPath("$.payload.accessToken", notNullValue()))
+                        .andExpect(jsonPath("$.payload.refreshToken", notNullValue()))
+                        .andExpect(status()
+                        .isOk());
+
+        AuthToken result = authTokenJpaRepository.findByMemberIdAndDeviceId(savedMember.getId(), deviceId);
+
+        assertThat(result.getMemberId()).isEqualTo(savedMember.getId());
+    }
+
+    @Test
+    @DisplayName("로그인 이메일 검증 실패")
+    public void signInEmailValidationFail() throws Exception {
+        // given
+        String email = "test";
+        String password = "password";
+        String deviceId = "deviceId";
+
+        SignInRequest request = new SignInRequest(email, password, deviceId);
+
+        // when & then
+        mockMvc.perform(post("/v1/member/sign-in")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                        .andDo(print())
+                        .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("로그인 비밀번호 불일치")
+    void memberSignInInvalidPassword() throws Exception {
+        // given
+        String email = "test@email";
+        String password = "password";
+        String deviceId = "deviceId";
+
+        this.createMember(email, password);
+
+        SignInRequest request = new SignInRequest(email, "invalid password", deviceId);
+
+        // when & then
+        mockMvc.perform(post("/v1/member/sign-in")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                        .andDo(print())
+                        .andExpect(status()
+                        .isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그인 이메일 불일치")
+    void memberSignInInvalidEmail() throws Exception {
+        // given
+        String email = "test@email";
+        String password = "password";
+        String deviceId = "deviceId";
+
+        this.createMember(email, password);
+
+        SignInRequest request = new SignInRequest("invalid@email", password, deviceId);
+
+        // when & then
+        mockMvc.perform(post("/v1/member/sign-in")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                        .andDo(print())
+                        .andExpect(jsonPath("$.message", is(ErrorCode.MEMBER_NOT_FOUND.getMessage())))
+                        .andExpect(status()
+                        .isNotFound());
+    }
+
+    private Member createMember(String email, String password) {
+        Member member = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .memberType(MemberType.MEMBER)
+                .balance(0)
+                .isDeleted(false)
+                .build();
+
+        return memberRepository.save(member);
     }
 }

--- a/src/test/java/com/flab/fpay/integration/member/v1/MemberIntegrationV1Test.java
+++ b/src/test/java/com/flab/fpay/integration/member/v1/MemberIntegrationV1Test.java
@@ -101,7 +101,14 @@ public class MemberIntegrationV1Test extends IntegrationTest {
 
         SignUpRequest request = new SignUpRequest(email, password);
 
-        Member member = new Member(email, password, MemberType.MEMBER, 0, false);
+        Member member = Member.builder()
+                .email(email)
+                .password(password)
+                .memberType(MemberType.MEMBER)
+                .balance(0)
+                .isDeleted(false)
+                .build();
+
         memberRepository.save(member);
 
         // when & then

--- a/src/test/java/com/flab/fpay/integration/member/v1/MemberIntegrationV1Test.java
+++ b/src/test/java/com/flab/fpay/integration/member/v1/MemberIntegrationV1Test.java
@@ -1,0 +1,116 @@
+package com.flab.fpay.integration.member.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.fpay.domain.member.dto.request.SignUpRequest;
+import com.flab.fpay.domain.member.entity.Member;
+import com.flab.fpay.domain.member.enums.MemberType;
+import com.flab.fpay.integration.IntegrationTest;
+import com.flab.fpay.repository.member.MemberJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class MemberIntegrationV1Test extends IntegrationTest {
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    MemberJpaRepository memberRepository;
+
+    @Test
+    @DisplayName("회원가입 성공")
+    public void signUpSuccess() throws Exception {
+        // given
+        String email = "test@email";
+        String password = "password";
+
+        SignUpRequest request = new SignUpRequest(email, password);
+
+        // when & then
+        mockMvc.perform(post("/v1/member/sign-up")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isCreated());
+
+        Member result = memberRepository.findAll().getFirst();
+
+        assertThat(result.getEmail()).isEqualTo(email);
+        assertThat(result.getBalance()).isZero();
+        assertThat(result.getDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("회원가입 이메일 검증 실패")
+    public void signUpEmailValidationFail() throws Exception {
+        // given
+        String email = "test";
+        String password = "password";
+
+        SignUpRequest request = new SignUpRequest(email, password);
+
+        // when & then
+        mockMvc.perform(post("/v1/member/sign-up")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("회원가입 비밀번호 검증 실패")
+    public void signUpPasswordValidationFail() throws Exception {
+        // given
+        String email = "test@gmail.com";
+        String password = "";
+
+        SignUpRequest request = new SignUpRequest(email, password);
+
+        // when & then
+        mockMvc.perform(post("/v1/member/sign-up")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(jsonPath("$.message", notNullValue()))
+                .andExpect(status()
+                .isBadRequest());
+    }
+
+    @Test
+    @DisplayName("회원가입 이메일 중복")
+    public void signUpDuplicatedEmail() throws Exception {
+        // given
+        String email = "test@gmail";
+        String password = "password";
+
+        SignUpRequest request = new SignUpRequest(email, password);
+
+        Member member = new Member(email, password, MemberType.MEMBER, 0, false);
+        memberRepository.save(member);
+
+        // when & then
+        mockMvc.perform(post("/v1/member/sign-up")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(jsonPath("$.message", is("duplicated email address")))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,3 @@
+spring:
+  jpa:
+    show-sql: true


### PR DESCRIPTION
회원 도메인의 핵심 기능을 구현했습니다. 작업한 기능은 다음과 같습니다.
- 회원 가입
- 로그인
- Refresh Token 재발급
- Access Token 검증 필터
- Access Token 클레임의 회원 ID와 요청의 회원 ID를 교차 검증하는 Aspect 추가
- 회원 상세 조회
